### PR TITLE
Upgrade hashie dependency to play nice with current versions.

### DIFF
--- a/pager_duty-connection.gemspec
+++ b/pager_duty-connection.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "faraday", "~> 0.8.6"
   gem.add_dependency "faraday_middleware", "~> 0.9.0"
   gem.add_dependency "activesupport", "~> 3.2"
-  gem.add_dependency "hashie", "~> 1.2"
+  gem.add_dependency "hashie", ">= 1.2", "< 2.2"
 end


### PR DESCRIPTION
I was running into some gem version conflicts using the library in an application depending on hashie 2.x. This seems to work well in all test cases so far.
