### PR TITLE
Don't try to parse entity body in time-parsing middleware when status co...

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -68,13 +68,15 @@ module PagerDuty
       def call(env)
         response = @app.call env
 
-        OBJECT_KEYS.each do |key|
-          object = env[:body][key]
-          parse_object_times(object) if object
-          
-          collection_key = key.pluralize
-          collection = env[:body][collection_key]
-          parse_collection_times(collection) if collection
+        if env[:body]
+          OBJECT_KEYS.each do |key|
+            object = env[:body][key]
+            parse_object_times(object) if object
+
+            collection_key = key.pluralize
+            collection = env[:body][collection_key]
+            parse_collection_times(collection) if collection
+          end
         end
 
         response


### PR DESCRIPTION
...de indicates a body-less response.
