### PR TITLE
Include more info in the API error messages

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -31,12 +31,13 @@ module PagerDuty
         response = @app.call env
         unless [200, 201, 204].include?(response.status)
           url = response.env[:url].to_s
+          message = "Got HTTP #{response['status']} back for #{url}"
           if error = response.body['error']
             # TODO May Need to check error.errors too
-            raise ApiError, "Got HTTP #{response['status']} back for #{url}. Error code #{error['code']}: #{error['message']}"
-          else
-            raise ApiError, "Got HTTP #{response['status']} back for #{url}."
+            message += "\n#{error.to_hash}"
           end
+
+          raise ApiError, message
         else
           response
         end


### PR DESCRIPTION
Before:

```
PagerDuty::Connection::ApiError: Got HTTP 400 Bad Request back for https://<redacted>.pagerduty.com/api/v1/schedules. Error code 3001: Invalid Schedule
```

After:

```
PagerDuty::Connection::ApiError: Got HTTP 400 Bad Request back for https://<redacted>.pagerduty.com/api/v1/schedules
{"message"=>"Invalid Schedule", "code"=>3001, "errors"=>["Schedule layers layer order can't be blank", "Schedule layers layer order is not a number", "Layer order can't be blank", "Layer order is not a number"]
```
