### PR TITLE
Add new keys for parsing time strings

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -45,7 +45,7 @@ module PagerDuty
       end
     end
 
-    class ConvertTimesParametersToISO8601  < Faraday::Middleware
+    class ConvertTimesParametersToISO8601 < Faraday::Middleware
       TIME_KEYS = [:since, :until]
       def call(env)
 
@@ -58,12 +58,11 @@ module PagerDuty
 
         response = @app.call env
       end
-
-
     end
 
     class ParseTimeStrings < Faraday::Response::Middleware
       TIME_KEYS = %w(
+        at
         created_at
         created_on
         end
@@ -84,6 +83,12 @@ module PagerDuty
         note
         override
         service
+      )
+
+      NESTED_COLLECTION_KEYS = %w(
+        acknowledgers
+        assigned_to
+        pending_actions
       )
 
       def parse(body)
@@ -107,6 +112,11 @@ module PagerDuty
       def parse_collection_times(collection)
         collection.each do |object|
           parse_object_times(object)
+
+          NESTED_COLLECTION_KEYS.each do |key|
+            object_collection = object[key]
+            parse_collection_times(object_collection) if object_collection
+          end
         end
       end
 


### PR DESCRIPTION
This commit adds new time and collection keys for parsing time
strings in the pager duty connection body. Whitespace cleanup was also
done in a few places.