### PR TITLE
delete upper bound on hashie gem version

### DIFF
--- a/pager_duty-connection.gemspec
+++ b/pager_duty-connection.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "faraday", "~> 0.8", "< 0.10"
   gem.add_dependency "faraday_middleware", "~> 0.9.0"
   gem.add_dependency "activesupport", ">= 3.2", "< 5.0"
-  gem.add_dependency "hashie", ">= 1.2", "< 2.2"
+  gem.add_dependency "hashie", ">= 1.2"
 end


### PR DESCRIPTION
It's been a while since upper bound on `hashie` gem version was set. Is the cause for it still valid? I tested with version `3.4.4` and worked fine. 
