### PR TITLE
Support v2 of Pager Duty REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Working code is worth a thousand words. The basics:
 
 ```ruby
 # setup the connection
-pagerduty = PagerDuty::Connection.new(account, token)
+pagerduty = PagerDuty::Connection.new(token, version)
 
-# 4 main methods: get, post, put, and delete:
+# 4 main methods: `get`, `post`, `put`, and `delete`:
 
-response = pagerduty.get('some/relative/path', :some => 'request', :parameter => 'to pass')
-response = pagerduty.post('some/relative/path', :some => 'request', :parameter => 'to pass')
-response = pagerduty.delete('some/relative/path', :some => 'request', :parameter => 'to pass')
-response = pagerduty.put('some/relative/path', :some => 'request', :parameter => 'to pass')
+response = pagerduty.get('some/relative/path', params)
+response = pagerduty.post('some/relative/path', params)
+response = pagerduty.delete('some/relative/path', params)
+response = pagerduty.put('some/relative/path', params)
 
 # use something like irb or pry to poke around the responses
 # the contents will vary a bit between call, ie:
@@ -63,6 +63,25 @@ response.incidents # an array of incidents
 
 response = pagerduty.get('incidents/YYZ')
 response # the hash/object that represents the array
+```
+
+`get`, `post`, `put`, and `delete` all take a common parameter `params`.
+This parameter contains the query parameters, body, and custom headers
+needed to perform the request. Params is structured as follows:
+
+```ruby
+params = {
+  query_params: {
+    param1: "ABCD",
+    ids: [ "id1", "id2", "id3" ] # Faraday takes care of encoding the arrays to be `?ids[]=id1&ids[]=id2&ids[]=id3..`
+  }, {
+    body: { ... }, # Whatever needs to be sent in a `PUT` or `POST` request body
+  }, {
+    headers: {
+      from: "testuser@test.com" # Some requests require a From header
+    }
+  }
+}
 ```
 
 For more advanced and realistic examples, check out the examples directory:

--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -16,6 +16,9 @@ module PagerDuty
     class ApiError < RuntimeError
     end
 
+    class RateLimitError < RuntimeError
+    end
+
     class RaiseFileNotFoundOn404 < Faraday::Middleware
       def call(env)
         response = @app.call env
@@ -42,6 +45,17 @@ module PagerDuty
         else
           response
         end
+      end
+    end
+
+    class RaiseRateLimitOn429 < Faraday::Middleware
+      def call(env)
+        response = @app.call env
+        if response.status == 429
+          raise RateLimitError, response.env[:url].to_s
+        end
+
+        response
       end
     end
 
@@ -131,58 +145,68 @@ module PagerDuty
       end
     end
 
-    def initialize(account, token, api_version = 1)
+    def initialize(token, api_version, debug: false)
       @api_version = api_version
       @connection = Faraday.new do |conn|
-        conn.url_prefix = "https://#{account}.pagerduty.com/api/v#{api_version}"
+        conn.url_prefix = "https://api.pagerduty.com/"
 
         # use token authentication: http://developer.pagerduty.com/documentation/rest/authentication
         conn.token_auth token
 
         conn.use RaiseApiErrorOnNon200
         conn.use RaiseFileNotFoundOn404
+        conn.use RaiseRateLimitOn429
 
         conn.use ConvertTimesParametersToISO8601
 
         # use json
         conn.request :json
+        conn.headers[:accept] = "application/vnd.pagerduty+json;version=#{api_version}"
 
         # json back, mashify it
         conn.use ParseTimeStrings
         conn.response :mashify
         conn.response :json
+        conn.response :logger, ::Logger.new(STDOUT), bodies: true if debug
 
         conn.adapter  Faraday.default_adapter
       end
     end
 
-    def get(path, options = {})
-      # paginate anything being 'get'ed, because the offset/limit isn't intutive
-      page = (options.delete(:page) || 1).to_i
-      limit = (options.delete(:limit) || 100).to_i
-      offset = (page - 1) * limit
-
-      run_request(:get, path, options.merge(:offset => offset, :limit => limit))
+    def get(path, params = {})
+      params[:query_params] = add_default_query_params(params)
+      run_request(:get, path, params)
     end
 
-    def put(path, options = {})
-      run_request(:put, path, options)
+    def put(path, params = {})
+      run_request(:put, path, params)
     end
 
-    def post(path, options = {})
-      run_request(:post, path, options)
+    def post(path, params = {})
+      run_request(:post, path, params)
     end
 
-    def delete(path, options = {})
-      run_request(:delete, path, options)
+    def delete(path, params = {})
+      run_request(:delete, path, params)
     end
 
-    def run_request(method, path, options)
+    private
+
+    def run_request(method, path, body: {}, headers: {}, query_params: {})
       path = path.gsub(/^\//, '') # strip leading slash, to make sure relative things happen on the connection
-      headers = nil
-      response = connection.run_request(method, path, options, headers)
+
+      connection.params = query_params
+      response = connection.run_request(method, path, body, headers)
       response.body
     end
 
+    def add_default_query_params(query_params: {})
+      # paginate anything being 'get'ed, because the offset/limit isn't intuitive
+      page = (query_params.delete(:page) || 1).to_i
+      limit = (query_params.delete(:limit) || 100).to_i
+      offset = (page - 1) * limit
+
+      query_params.merge(offset: offset, limit: limit)
+    end
   end
 end


### PR DESCRIPTION
This commit updates the Connection class to support only v2+ of
the Pager Duty REST API. Updates have been made following the migration
document https://v2.developer.pagerduty.com/docs/migrating-to-api-v2.
Notable v2 updates include:

- Required 'Accept' request header which includes version number
- Base URL has changed, so account_domain is no longer needed
- Rate limiting error handling
- requester_id (user id) is no longer sent as a query parameter to
identify the requesting user. Instead, set the From header to the
request user's email address in the headers hash as needed.

In addition to these v2 updates, method signatures have been changed, which
was the main motivation for no longer supporting v1. Prior to
this update, the query parameters were sent through the request body,
which worked for v1 but not for v2.

One of the changes made to v2 was to
restructure the way lists are sent as query parameters. Instead of
having test.com/some_uri?status=status1,status2,status3, we now need to
support
test.com/some_url?statuses[]=status1&statuses[]=status2&statuses[]=status3. Faraday supports encoding query parameters this way, but when sent through the body, arrays are encoded as JSON and so they do not align with what the API requires. Additionally, now that requester_id is added as a header value, it makes sense to separate the request body, headers, and query parameters.

Additionally, we no longer default to any version of the API. The API
version should be sent when initializing PagerDuty::Connection.

[151816727386211](https://app.asana.com/0/151816727386211/151816727386211)