### PR TITLE
Bump Faraday and faraday_middleware to 0.14, 12.2 respectively

### DIFF
--- a/pager_duty-connection.gemspec
+++ b/pager_duty-connection.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "faraday", "~> 0.8", "< 0.10"
-  gem.add_dependency "faraday_middleware", "~> 0.9.0"
+  gem.add_dependency "faraday", "~> 0.14"
+  gem.add_dependency "faraday_middleware", "~> 0.12.0"
   gem.add_dependency "activesupport", ">= 3.2", "< 5.0"
   gem.add_dependency "hashie", ">= 1.2"
 end


### PR DESCRIPTION
Needed to bump these gems up to the newest version. This is the first of many changes to allow the gem to run on newer versions of rails.

Overall the changes refactor and the gem appears to run normally. 

[Faraday Diff 0.8 and 0.14](https://github.com/lostisland/faraday/compare/0.8...v0.14.0)
[Faraday Middleware Diff 0.9.0 and 0.12.0](https://github.com/lostisland/faraday_middleware/compare/0.9...0.10)