### PR TITLE
Fix up docs for Connection initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Working code is worth a thousand words. The basics:
 
 ```ruby
 # setup the connection
-pagerduty = PagerDuty::Connection.new(token, version)
+pagerduty = PagerDuty::Connection.new(token)
 
 # 4 main methods: `get`, `post`, `put`, and `delete`:
 
@@ -96,7 +96,7 @@ In general, you can get/put/post/delete a path, with some attributes. Use the [R
 If you are working in Rails, and using only a single PagerDuty account, you'll probably want an initializer:
 
 ```ruby
-$pagerduty = PagerDuty::Connection.new('your-subdomain', 'your-token')
+$pagerduty = PagerDuty::Connection.new('your-token')
 ```
 
 And if you are using [dotenv](https://github.com/bkeepers/dotenv), you can use environment variables, and stash them in .env:


### PR DESCRIPTION
When reading through the ReadMe the initialization of the `PagerDuty::Connection` was different in some examples. I looked at class and the signature for the Connection class was

```ruby
def initialize(token, debug: false)
```

Making a small change to. Thanks for making this 💎