### PR TITLE
Update deps for newer faraday and rails

### DIFF
--- a/pager_duty-connection.gemspec
+++ b/pager_duty-connection.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "faraday", "~> 0.8", "< 0.10"
-  gem.add_dependency "faraday_middleware", "~> 0.9.0"
-  gem.add_dependency "activesupport", ">= 3.2", "< 5.0"
+  gem.add_dependency "faraday", "~> 0.8", "< 1.0"
+  gem.add_dependency "faraday_middleware", "~> 0.8", "< 1.0"
+  gem.add_dependency "activesupport", ">= 3.2", "< 6.0"
   gem.add_dependency "hashie", ">= 1.2"
 end


### PR DESCRIPTION
This will allow pager_duty-connection to be installed with newer versions of faraday and rails 5.  I tested this locally against the latest faraday and rails with no issues.