### PR TITLE
handle OAuth2 bearer tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ Or install it yourself as:
 Working code is worth a thousand words. The basics:
 
 ```ruby
-# setup the connection
+# setup the connection with API token
 pagerduty = PagerDuty::Connection.new(token)
+
+# setup the connection with OAuth2 token
+pagerduty = PagerDuty::Connection.new(token, :Bearer)
 
 # 4 main methods: `get`, `post`, `put`, and `delete`:
 

--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -146,12 +146,12 @@ module PagerDuty
       end
     end
 
-    def initialize(token, debug: false)
+    def initialize(token, token_type: :Token, debug: false)
       @connection = Faraday.new do |conn|
         conn.url_prefix = "https://api.pagerduty.com/"
 
         # use token authentication: http://developer.pagerduty.com/documentation/rest/authentication
-        conn.token_auth token
+        conn.authorization(token_type, token)
 
         conn.use RaiseApiErrorOnNon200
         conn.use RaiseFileNotFoundOn404

--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -150,7 +150,6 @@ module PagerDuty
       @connection = Faraday.new do |conn|
         conn.url_prefix = "https://api.pagerduty.com/"
 
-        # use token authentication: http://developer.pagerduty.com/documentation/rest/authentication
         conn.authorization(token_type, token)
 
         conn.use RaiseApiErrorOnNon200


### PR DESCRIPTION
Adds support for [OAuth 2 authentication](https://v2.developer.pagerduty.com/docs/oauth-2-functionality) in addition to [API Token authentication](https://v2.developer.pagerduty.com/docs/authentication)