### PR TITLE
Fix token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Working code is worth a thousand words. The basics:
 pagerduty = PagerDuty::Connection.new(token)
 
 # setup the connection with OAuth2 token
-pagerduty = PagerDuty::Connection.new(token, :Bearer)
+pagerduty = PagerDuty::Connection.new(token, token_type: :Bearer)
 
 # 4 main methods: `get`, `post`, `put`, and `delete`:
 

--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -150,7 +150,13 @@ module PagerDuty
       @connection = Faraday.new do |conn|
         conn.url_prefix = "https://api.pagerduty.com/"
 
-        conn.authorization(token_type, token)
+        token_arg =
+          case token_type
+          when :Token then { token: token }
+          when :Bearer then token
+          else raise ArgumentError, "invalid token_type: #{token_type.inspect}"
+          end
+        conn.authorization(token_type, token_arg)
 
         conn.use RaiseApiErrorOnNon200
         conn.use RaiseFileNotFoundOn404


### PR DESCRIPTION
If you use token authentication on version 1.2.0 of the gem, you get this error:

    irb(main):006:0> PagerDuty::Connection.new(token).get('incidents')
    Traceback (most recent call last):
           16: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.2.0/exe/irb:11:in `<top (required)>'
           15: from (irb):6
           14: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pager_duty-connection-1.2.0/lib/pager_duty/connection.rb:183:in `get'
           13: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pager_duty-connection-1.2.0/lib/pager_duty/connection.rb:204:in `run_request'
           12: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-0.17.1/lib/faraday/connection.rb:387:in `run_request'
           11: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-0.17.1/lib/faraday/rack_builder.rb:143:in `build_response'
           10: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pager_duty-connection-1.2.0/lib/pager_duty/connection.rb:36:in `call'
            9: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pager_duty-connection-1.2.0/lib/pager_duty/connection.rb:25:in `call'
            8: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pager_duty-connection-1.2.0/lib/pager_duty/connection.rb:54:in `call'
            7: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pager_duty-connection-1.2.0/lib/pager_duty/connection.rb:74:in `call'
            6: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday_middleware-0.13.1/lib/faraday_middleware/request/encode_json.rb:24:in `call'
            5: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-0.17.1/lib/faraday/response.rb:8:in `call'
            4: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-0.17.1/lib/faraday/response.rb:61:in `on_complete'
            3: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-0.17.1/lib/faraday/response.rb:9:in `block in call'
            2: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-0.17.1/lib/faraday/response.rb:16:in `on_complete'
            1: from /Users/pat/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pager_duty-connection-1.2.0/lib/pager_duty/connection.rb:123:in `parse'
    RuntimeError (Can't parse times of NilClass: )

Faraday gives these examples in [its documentation](https://www.rubydoc.info/github/lostisland/faraday/Faraday%2FConnection:authorization):

    conn.authorization :Bearer, 'mF_9.B5f-4.1JqM'
    conn.headers['Authorization']
    # => "Bearer mF_9.B5f-4.1JqM"

    conn.authorization :Token, :token => 'abcdef', :foo => 'bar'
    conn.headers['Authorization']
    # => "Token token=\"abcdef\",
                foo=\"bar\""

So when you use token authentication, you need to pass a hash, not just a string.