### PR TITLE
Explicitly pass request as kwargs to run_request

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -186,19 +186,19 @@ module PagerDuty
       offset = (page - 1) * limit
       request[:query_params] = request[:query_params].merge(offset: offset, limit: limit)
 
-      run_request(:get, path, request)
+      run_request(:get, path, **request)
     end
 
     def put(path, request = {})
-      run_request(:put, path, request)
+      run_request(:put, path, **request)
     end
 
     def post(path, request = {})
-      run_request(:post, path, request)
+      run_request(:post, path, **request)
     end
 
     def delete(path, request = {})
-      run_request(:delete, path, request)
+      run_request(:delete, path, **request)
     end
 
     private


### PR DESCRIPTION
Fixes #32, which highlights this particular code path as a Ruby 2.7 deprecation warning.