### PR TITLE
Bump faraday gemspec version

### DIFF
--- a/pager_duty-connection.gemspec
+++ b/pager_duty-connection.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "faraday", "~> 0.8", "< 1.0"
-  gem.add_dependency "faraday_middleware", "~> 0.8", "< 1.0"
+  gem.add_dependency "faraday", "~> 1.0.0"
+  gem.add_dependency "faraday_middleware", "~> 1.0.0"
   gem.add_dependency "activesupport", ">= 3.2", "< 7.0"
   gem.add_dependency "hashie", ">= 1.2"
 end


### PR DESCRIPTION
Faraday was updated to 1.0 in December 2019, and several other gems have updated to the major as well, causing a conflict. For example the Stripe gem, as well as several other API related ones in our project.

This just bumps the version in the gemspec, I'd definitely release this as a major since it will wreak havoc or minor / patch level gemfile's for folks.