### PR TITLE
Support parsing `Array` response in `ParseTimeStrings`

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -119,6 +119,8 @@ module PagerDuty
           end
 
           body
+        when Array
+          body.map! { |element| parse(element) }
         else
           raise "Can't parse times of #{body.class}: #{body}"
         end


### PR DESCRIPTION
👋 Hey @technicalpickles!  

I've been using version `2.0.0` of this gem and spotted what I _believe_ is an unhandled parsing case.  I encounter the error when the PD API returns a response of type `Array`.  It appears that `parse` will [`raise` on anything other than `Hash` or `::Hashie::Mash`](https://github.com/technicalpickles/pager_duty-connection/blob/fd3678f12dd7e00a5e759493f7d87260c9859f78/lib/pager_duty/connection.rb#L123).

Here's the stacktrace I was getting before the changes introduced in this PR:

```ruby
/usr/local/bundle/gems/pager_duty-connection-2.0.0/lib/pager_duty/connection.rb:123:in `parse': Can't parse times of Array: [#<Hashie::Mash override=... status=201>, #<Hashie::Mash override=... status=201>, #<Hashie::Mash override=... status=201>, #<Hashie::Mash override=... status=201>, #<Hashie::Mash override=... status=201>] (RuntimeError)
	from /usr/local/bundle/gems/faraday-1.0.1/lib/faraday/response.rb:22:in `on_complete'
	from /usr/local/bundle/gems/faraday-1.0.1/lib/faraday/response.rb:12:in `block in call'
	from /usr/local/bundle/gems/faraday-1.0.1/lib/faraday/response.rb:65:in `on_complete'
	from /usr/local/bundle/gems/faraday-1.0.1/lib/faraday/response.rb:11:in `call'
	from /usr/local/bundle/gems/faraday_middleware-1.0.0/lib/faraday_middleware/request/encode_json.rb:26:in `call'
	from /usr/local/bundle/gems/pager_duty-connection-2.0.0/lib/pager_duty/connection.rb:74:in `call'
	from /usr/local/bundle/gems/pager_duty-connection-2.0.0/lib/pager_duty/connection.rb:54:in `call'
	from /usr/local/bundle/gems/pager_duty-connection-2.0.0/lib/pager_duty/connection.rb:25:in `call'
	from /usr/local/bundle/gems/pager_duty-connection-2.0.0/lib/pager_duty/connection.rb:36:in `call'
	from /usr/local/bundle/gems/faraday-1.0.1/lib/faraday/rack_builder.rb:153:in `build_response'
	from /usr/local/bundle/gems/faraday-1.0.1/lib/faraday/connection.rb:492:in `run_request'
	from /usr/local/bundle/gems/pager_duty-connection-2.0.0/lib/pager_duty/connection.rb:210:in `run_request'
	from /usr/local/bundle/gems/pager_duty-connection-2.0.0/lib/pager_duty/connection.rb:197:in `post'
        ...
```

Here's the [response example for the `POST /schedules/{id}/overrides` call](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1schedules~1%7Bid%7D~1overrides/post) that produces the above error:

```json
[
    {
        "status": 201,
        "override": {
            "start": "2021-03-09T05:00:00Z",
            "end": "2021-03-09T17:00:00Z",
            "user": {
                "id": "P37CSDJ",
                "type": "user_reference",
                "summary": "Scott",
                "self": "https://api.pd-staging.com/users/P37CSDJ",
                "html_url": "https://pdt-braythwayt.pd-staging.com/users/P37CSDJ"
            },
            "id": "Q3X6MJ1LUKD6QW"
        }
    },
    {...},
    {...}
]
```

After the changes introduced in this PR, the output of the parsed response in my sample case (scheduling multiple overrides) is as follows (_response modified to remove personal information_):

```ruby
[#<Hashie::Mash override=#<Hashie::Mash end=2021-10-11 22:00:00 UTC ... start=2021-10-11 14:00:00 UTC user=... status=201>, #<Hashie::Mash override=#<Hashie::Mash end=2021-10-12 22:00:00 UTC ... start=2021-10-12 14:00:00 UTC ... status=201>, ..., ..., ...]
```

Thanks for taking a look! Let me know if there's anything else I should add here.