### PR TITLE
allow passing of api prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ pagerduty = PagerDuty::Connection.new(token)
 # setup the connection with OAuth2 token
 pagerduty = PagerDuty::Connection.new(token, token_type: :Bearer)
 
+# setup to use a custom domain
+pagerduty = PagerDuty::Connection.new(token, token_type: :Bearer, url: 'https://custom.domain.com')
+
 # 4 main methods: `get`, `post`, `put`, and `delete`:
 
 response = pagerduty.get('some/relative/path', params)

--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -10,6 +10,7 @@ module PagerDuty
     attr_accessor :connection
 
     API_VERSION = 2
+    API_PREFIX = "https://api.pagerduty.com/"
 
     class FileNotFoundError < RuntimeError
     end
@@ -148,9 +149,9 @@ module PagerDuty
       end
     end
 
-    def initialize(token, token_type: :Token, debug: false)
+    def initialize(token, token_type: :Token, url: API_PREFIX, debug: false)
       @connection = Faraday.new do |conn|
-        conn.url_prefix = "https://api.pagerduty.com/"
+        conn.url_prefix = url
 
         token_arg =
           case token_type


### PR DESCRIPTION
pager duty allows hosting at custom urls, so sometimes passing the api
url prefix is required.