### PR TITLE
Fix error when running a get("/rulesets/"+rulesed_id) with invalid ruleset_id

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -39,7 +39,12 @@ module PagerDuty
           message = "Got HTTP #{response['status']} back for #{url}"
           if error = response.body['error']
             # TODO May Need to check error.errors too
-            message += "\n#{error.to_hash}"
+			begin
+			  message += "\n#{error.to_hash}"
+			rescue NoMethodError => e
+			  message += error
+			end
+
           end
 
           raise ApiError, message

--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -36,15 +36,11 @@ module PagerDuty
         response = @app.call env
         unless [200, 201, 204].include?(response.status)
           url = response.env[:url].to_s
-          message = "Got HTTP #{response['status']} back for #{url}"
-          if error = response.body['error']
-            # TODO May Need to check error.errors too
-			begin
-			  message += "\n#{error.to_hash}"
-			rescue NoMethodError => e
-			  message += error
-			end
+          message = "Got HTTP #{response.status}: #{response.reason_phrase}\nFrom #{url}"
 
+          if error = response.body
+            # TODO May Need to check error.errors too
+            message += "\n#{JSON.parse(error)}"
           end
 
           raise ApiError, message


### PR DESCRIPTION
If I call get("/rulesets/"+rs_id) with an id that doesn't exist, I get the unhelpful error:

undefined method `to_hash' for "error":String (NoMethodError)

With this change in place, I am able to get:

Got HTTP  back for https://api.pagerduty.com/rulesets/__BAD_ID__?limit=100&offset=0error (PagerDuty::Connection::ApiError)
