### PR TITLE
Refactor `PagerDuty::Connection#get` so it doesn't mutate the input

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -187,12 +187,13 @@ module PagerDuty
     def get(path, request = {})
       # paginate anything being 'get'ed, because the offset/limit isn't intuitive
       request[:query_params] = {} if !request[:query_params]
-      page = (request[:query_params].delete(:page) || 1).to_i
-      limit = (request[:query_params].delete(:limit) || 100).to_i
+      page = request[:query_params].fetch(:page, 1).to_i
+      limit = request[:query_params].fetch(:limit, 100).to_i
       offset = (page - 1) * limit
-      request[:query_params] = request[:query_params].merge(offset: offset, limit: limit)
 
-      run_request(:get, path, **request)
+      query_params = request[:query_params].merge(offset: offset, limit: limit)
+
+      run_request(:get, path, **request.merge(query_params: query_params))
     end
 
     def put(path, request = {})


### PR DESCRIPTION
This refactors `PagerDuty::Connection#get` so that it doesn't mutate the `request` passed to it.

At the moment, it mutates the `:query_params` key inside the `request`, potentially dropping the `:page` and `:limit` keys (due to use of `Hash#delete`) and adding a calculated `:offset`.

Mutating the incoming value isn't a problem - but it's certainly a bit surprising, and an issue that a user is likely to run into when paginating through records with a Ruby `loop`.