### PR TITLE
Use updated Faraday syntax

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -154,13 +154,13 @@ module PagerDuty
       @connection = Faraday.new do |conn|
         conn.url_prefix = url
 
-        token_arg =
-          case token_type
-          when :Token then { token: token }
-          when :Bearer then token
-          else raise ArgumentError, "invalid token_type: #{token_type.inspect}"
-          end
-        conn.authorization(token_type, token_arg)
+        case token_type
+        when :Token
+          conn.request :token_auth, token
+        when :Bearer
+          conn.request :authorization, 'Bearer', token
+        else raise ArgumentError, "invalid token_type: #{token_type.inspect}"
+        end
 
         conn.use ConvertTimesParametersToISO8601
 


### PR DESCRIPTION
Updates the authorization syntax for Faraday v1.x as per https://lostisland.github.io/faraday/middleware/authentication to remove the deprecation warning:

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

Fixes #49