### PR TITLE
filter custom page query param from outgoing PD requests

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -230,6 +230,7 @@ module PagerDuty
       offset = (page - 1) * limit
 
       query_params = request[:query_params].merge(offset: offset, limit: limit)
+      query_params.delete(:page)
 
       run_request(:get, path, **request.merge(query_params: query_params))
     end


### PR DESCRIPTION
PagerDuty does not understand the custom page parameter this library adds, so including it in the outbound requests is pointless.

Including it makes mocking/testing of outbound requests harder as they no longer match 1:1 with pagerduty docs. 