### PR TITLE
Adds faraday 2 support, with backwards compatibility for faraday 1

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-require 'faraday_middleware'
+require 'hashie'
 require 'active_support'
 require 'active_support/core_ext'
 require 'active_support/time_with_zone'
@@ -106,7 +106,7 @@ module PagerDuty
       end
     end
 
-    class ParseTimeStrings < Faraday::Response::Middleware
+    class ParseTimeStrings < Faraday::Middleware
       TIME_KEYS = %w(
         at
         created_at
@@ -136,6 +136,10 @@ module PagerDuty
         assigned_to
         pending_actions
       )
+
+      def on_complete(env)
+        parse(env[:body])
+      end
 
       def parse(body)
         case body
@@ -179,13 +183,34 @@ module PagerDuty
       end
     end
 
+    class Mashify < Faraday::Middleware
+      def on_complete(env)
+        env[:body] = parse(env[:body])
+      end
+
+      def parse(body)
+        case body
+        when Hash
+          ::Hashie::Mash.new(body)
+        when Array
+          body.map { |item| parse(item) }
+        else
+          body
+        end
+      end
+    end
+
     def initialize(token, token_type: :Token, url: API_PREFIX, debug: false)
       @connection = Faraday.new do |conn|
         conn.url_prefix = url
 
         case token_type
         when :Token
-          conn.request :token_auth, token
+          if faraday_v1?
+            conn.request :token_auth, token
+          else
+            conn.request :authorization, 'Token', token
+          end
         when :Bearer
           conn.request :authorization, 'Bearer', token
         else raise ArgumentError, "invalid token_type: #{token_type.inspect}"
@@ -199,7 +224,7 @@ module PagerDuty
 
         # json back, mashify it
         conn.use ParseTimeStrings
-        conn.response :mashify
+        conn.use Mashify
         conn.response :json
         conn.response :logger, ::Logger.new(STDOUT), bodies: true if debug
 
@@ -247,6 +272,14 @@ module PagerDuty
     end
 
     private
+
+    def faraday_v1?
+      faraday_version < Gem::Version.new("2") 
+    end
+
+    def faraday_version
+      @faraday_version ||= Gem.loaded_specs["faraday"].version
+    end
 
     def run_request(method, path, body: {}, headers: {}, query_params: {})
       path = path.gsub(/^\//, '') # strip leading slash, to make sure relative things happen on the connection

--- a/pager_duty-connection.gemspec
+++ b/pager_duty-connection.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "faraday", "~> 1.0"
-  gem.add_dependency "faraday_middleware", "~> 1.0"
+  gem.add_dependency "faraday", ">= 1.10", "< 3"
   gem.add_dependency "activesupport", ">= 3.2", "< 8.0"
   gem.add_dependency "hashie", ">= 1.2"
 


### PR DESCRIPTION
Adds support for `faraday` 2 while still working with `faraday` 1.10 and above

1. Changes `faraday` dependency to `">= 1.10", "< 3"`
2. Removes dependency on the deprecated [faraday_middleware](https://github.com/lostisland/faraday_middleware) gem. This is possible because starting at version [1.10](https://github.com/lostisland/faraday/releases/tag/v1.10.0) `faraday` includes the json middleware by default.
3. Includes a simple `Mashify` middleware instead of using [faraday-mashify](https://github.com/sue445/faraday-mashify) since that gem is only compatible with `faraday` 2.
4. Removes `Faraday::Response::Middleware` (which was dropped in `faraday` 2) in favor of using `on_complete` which has been suported since `faraday` [1.2](https://github.com/lostisland/faraday/releases/tag/v1.2.0)
5. Adds a `faraday_v1?` check for configuring the request authorization middleware, which changed slightly in `faraday` 2