### PR TITLE
Version bump to 3.0.0

### DIFF
--- a/lib/pager_duty/connection/version.rb
+++ b/lib/pager_duty/connection/version.rb
@@ -1,5 +1,5 @@
 module PagerDuty
   class Connection
-    VERSION = "2.3.0"
+    VERSION = "3.0.0"
   end
 end


### PR DESCRIPTION
Featuring:

- https://github.com/technicalpickles/pager_duty-connection/pull/59 by @mattbnz
- https://github.com/technicalpickles/pager_duty-connection/pull/60 by @jasondoc3 

Making this 3.0, since it #60 does change the dependencies to not include faraday_middleware anymore.