### PR TITLE
Relax activesupport constraint to support Rails 8

### DIFF
--- a/pager_duty-connection.gemspec
+++ b/pager_duty-connection.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "faraday", ">= 1.10", "< 3"
-  gem.add_dependency "activesupport", ">= 3.2", "< 8.0"
+  gem.add_dependency "activesupport", ">= 3.2", "< 9.0"
   gem.add_dependency "hashie", ">= 1.2"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Rails 8 has been released, but is incompatible with this gem due to a constraint on activesupport. By expanding the constraint, this gem can continue to be used with Rails 8.