### PR TITLE
Connection.rb: Allow string and empty response body

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -154,7 +154,7 @@ module PagerDuty
         when Array
           body.map! { |element| parse(element) }
         else
-          raise "Can't parse times of #{body.class}: #{body}"
+          body
         end
       end
 


### PR DESCRIPTION
There are certain responses that only respond with a status code, and an empty body like all of the `DELETE` requests. For example: [delete_webhook](https://developer.pagerduty.com/api-reference/851394f7839aa-delete-a-webhook-subscription). 

This change makes parsing the body (in particular, `ParseTimeStrings`) more permissive, and doesn't `raise` for valid requests:

```
connection = PagerDuty::Connection.new(token, token_type: :Bearer)
id = "PXXXXX"
connection.delete("webhook_subscriptions/#{id}")

# before
= >  Can't parse times of String:  (RuntimeError)

# after
 => "" 
```